### PR TITLE
Fix exception.getResponse is not a function exception

### DIFF
--- a/src/response/filters/http-exception/http-exception.filter.ts
+++ b/src/response/filters/http-exception/http-exception.filter.ts
@@ -26,7 +26,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
       correlation_id:
           request.headers['x-correlation-id'] ||
           request.headers['correlation-id'],
-      message: exception.getResponse(),
+      message: exception.getResponse?.() || exception.message || 'Internal server error',
     };
 
     response.status(status).json(errorResponse);


### PR DESCRIPTION
Addressing exceptions with:

```

api  | Unhandled Rejection at: Promise {
api  |   <rejected> TypeError: exception.getResponse is not a function
api  |       at HttpExceptionFilter.catch (/usr/src/app/node_modules/@alti-js/nestjs-common/src/response/filters/http-exception/http-exception.filter.ts:29:26)
api  |       at ExceptionsHandler.invokeCustomFilters (/usr/src/app/node_modules/@nestjs/core/exceptions/exceptions-handler.js:30:26)
api  |       at ExceptionsHandler.next (/usr/src/app/node_modules/@nestjs/core/exceptions/exceptions-handler.js:14:18)
api  |       at /usr/src/app/node_modules/@nestjs/core/router/router-proxy.js:13:35
api  |       at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```